### PR TITLE
Fix: Add web app service IP to security group rule

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -40,6 +40,25 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/dns" {
+  version = "3.2.4"
+  hashes = [
+    "h1:+S0SAfuuYh7LtMoHbX4soqWhAAs92hUQ1kWuJ7uUeMg=",
+    "zh:13f1284887be8ebcf279e0e84d685751fbd40bd1f1abbea0ee6ba57bae5bcc4f",
+    "zh:22e7428d6af0cbb2191b17da9406b4cfc110ab2ce57ee818d505dbdc03cab325",
+    "zh:3690ec6483dd879a292592859d38391813d48f2efeceafcc7bae4a0e34cfc9f9",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8a9b713c80e5fa288bd4a942974307c835c434c2370a600977abbc7e3b71fbc4",
+    "zh:96a033b54ec602b6daa669d4913d33ed9ad5751fafce5ec94df6c2accaa93ba5",
+    "zh:cc64dd880e91a32e112a0a030240f096606162da74e3a8e454c0f31553080bfd",
+    "zh:db30eb45ad3c295c953d8c6063354d9c3c97b7b208ae4cf8b454b4ea973c577d",
+    "zh:dfe060ccd4d1ea363227e9b19b87a024e75d7a1f4f5147bf367b2f5991b9667c",
+    "zh:f290a90e9130204bb01557a842232496c2ab0de9aa3de32fc21125d35333486b",
+    "zh:f688e49913c21d14765558b239a236d2cc7c7dd10c77b78e3dc1767cbd4e94ef",
+    "zh:fb34249421e6fd4d364518f657811e752f38d7bc234f17c0b3cb704e6f1b0057",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/null" {
   version     = "3.2.1"
   constraints = ">= 3.2.1"

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ module "azure_web_app_services_hosting" {
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.1 |
 | <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | >= 1.4.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.48.0 |
+| <a name="requirement_dns"></a> [dns](#requirement\_dns) | >= 3.2.4 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |
 
 ## Providers
@@ -208,6 +209,7 @@ module "azure_web_app_services_hosting" {
 | Name | Version |
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.48.0 |
+| <a name="provider_dns"></a> [dns](#provider\_dns) | 3.2.4 |
 
 ## Resources
 
@@ -264,6 +266,7 @@ module "azure_web_app_services_hosting" {
 | [azurerm_resource_group.existing_resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_storage_account_blob_container_sas.logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account_blob_container_sas) | data source |
 | [azurerm_virtual_network.existing_virtual_network](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |
+| [dns_a_record_set.web_app_service_ip_address](https://registry.terraform.io/providers/hashicorp/dns/latest/docs/data-sources/a_record_set) | data source |
 
 ## Inputs
 

--- a/data.tf
+++ b/data.tf
@@ -10,3 +10,7 @@ data "azurerm_resource_group" "existing_resource_group" {
 
   name = local.existing_resource_group
 }
+
+data "dns_a_record_set" "web_app_service_ip_address" {
+  host = local.service_app.default_hostname
+}

--- a/versions.tf
+++ b/versions.tf
@@ -9,6 +9,10 @@ terraform {
       source  = "Azure/azapi"
       version = ">= 1.4.0"
     }
+    dns = {
+      source  = "hashicorp/dns"
+      version = ">= 3.2.4"
+    }
     null = {
       source  = "hashicorp/null"
       version = ">= 3.2.1"

--- a/virtual-network.tf
+++ b/virtual-network.tf
@@ -63,7 +63,7 @@ resource "azurerm_network_security_group" "web_app_service_infra_allow_frontdoor
     source_port_range          = "*"
     destination_port_range     = "443"
     source_address_prefix      = "AzureFrontDoor.Backend"
-    destination_address_prefix = ""
+    destination_address_prefix = "${data.dns_a_record_set.web_app_service_ip_address.addrs[0]}/32"
   }
 
   tags = local.tags


### PR DESCRIPTION
* Because we can't get the IP of the Web App service from the resource, we need to use the DNS provider the find the IP.