### PR TITLE
Switch to using a Log Query alert for Exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,10 +289,10 @@ module "azure_web_app_services_hosting" {
 | [azurerm_monitor_diagnostic_setting.web_app_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_diagnostic_setting.webhook](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_metric_alert.cpu](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
-| [azurerm_monitor_metric_alert.exceptions](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.http](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.latency](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.memory](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert_v2.exceptions](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_nat_gateway.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/nat_gateway) | resource |
 | [azurerm_nat_gateway_public_ip_association.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/nat_gateway_public_ip_association) | resource |
 | [azurerm_network_security_group.web_app_service_infra](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_group) | resource |

--- a/monitor.tf
+++ b/monitor.tf
@@ -161,27 +161,72 @@ resource "azurerm_monitor_metric_alert" "memory" {
   tags = local.tags
 }
 
-resource "azurerm_monitor_metric_alert" "exceptions" {
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "exceptions" {
   count = local.enable_monitoring ? 1 : 0
 
-  name                = "${local.resource_prefix}-exceptions"
-  resource_group_name = local.resource_group.name
-  scopes              = [azurerm_application_insights.web_app_service.id]
-  description         = "Action will be triggered when the number of exceptions exceeds 0"
-  window_size         = "PT5M"
-  frequency           = "PT1M"
-  severity            = 2
+  name                 = "${azurerm_application_insights.web_app_service.name}-exceptions"
+  resource_group_name  = local.resource_group.name
+  location             = local.resource_group.location
+  evaluation_frequency = "PT5M"
+  window_duration      = "PT5M"
+  scopes               = [azurerm_application_insights.web_app_service.id]
+  severity             = 2
+  description          = "Action will be triggered when an Exception is raised in App Insights"
 
   criteria {
-    metric_namespace = "Microsoft.Insights/components"
-    metric_name      = "exceptions/count"
-    aggregation      = "Count"
-    operator         = "GreaterThan"
-    threshold        = 0
+    query = <<-QUERY
+      exceptions
+        | where timestamp > ago(5min)
+        | project cloud_RoleInstance, type, outerMessage, innermostMessage
+        | summarize ErrorCount=count() by cloud_RoleInstance, type, outerMessage, innermostMessage
+        | project ErrorCount, cloud_RoleInstance, type, outerMessage, innermostMessage
+        | order by ErrorCount desc
+      QUERY
+
+    time_aggregation_method = "Count"
+    threshold               = 1
+    operator                = "GreaterThanOrEqual"
+
+    dimension {
+      name     = "ErrorCount"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    dimension {
+      name     = "cloud_RoleInstance"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    dimension {
+      name     = "type"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    dimension {
+      name     = "outerMessage"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    dimension {
+      name     = "innermostMessage"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
   }
 
+  auto_mitigation_enabled = false
+
   action {
-    action_group_id = azurerm_monitor_action_group.web_app_service[0].id
+    action_groups = [azurerm_monitor_action_group.web_app_service[0].id]
   }
 
   tags = local.tags


### PR DESCRIPTION
**Why do we need this?**
The previous Alert Rule only told us that an Exception had occurred but didn't include any more details, which meant people had to log in to Azure to view the actual exception message.

This is clunky and not very useful for developers who may not have experience using Log Analytics/App Insights

**What does it do?**
Replaces the old metric alert with a log query alert instead. The Log query includes information on the exception such as the Container Instance, and crucially, the Error Message