### PR TITLE
Add low priority default deny rule to ACL

### DIFF
--- a/app-service-linux.tf
+++ b/app-service-linux.tf
@@ -65,6 +65,17 @@ resource "azurerm_linux_web_app" "default" {
         ip_address = ip_restriction.value
       }
     }
+
+    dynamic "ip_restriction" {
+      for_each = length(local.web_app_service_allow_ips_inbound) > 0 ? [1] : []
+
+      content {
+        name       = "Deny from Any"
+        ip_address = "0.0.0.0/0"
+        action     = "Deny"
+        priority   = 2147483647
+      }
+    }
   }
 
   dynamic "logs" {

--- a/app-service-windows.tf
+++ b/app-service-windows.tf
@@ -62,6 +62,17 @@ resource "azurerm_windows_web_app" "default" {
         ip_address = ip_restriction.value
       }
     }
+
+    dynamic "ip_restriction" {
+      for_each = length(local.web_app_service_allow_ips_inbound) > 0 ? [1] : []
+
+      content {
+        name       = "Deny from Any"
+        ip_address = "0.0.0.0/0"
+        action     = "Deny"
+        priority   = 2147483647
+      }
+    }
   }
 
   dynamic "logs" {


### PR DESCRIPTION
* Due to there being a feature missing from azurerm, it is not currently possible to set the default action to Deny using Terraform. A work around for this is to set a low priority deny rule with a source IP address of 0.0.0.0/0

Related: 
- https://github.com/hashicorp/terraform-provider-azurerm/issues/22593
- https://github.com/Azure/azure-rest-api-specs/issues/24215