### PR TITLE
Add terraform checkov workflow.

### DIFF
--- a/.github/workflows/continuous-integration-checkov-terraform.yml
+++ b/.github/workflows/continuous-integration-checkov-terraform.yml
@@ -1,0 +1,20 @@
+name: Checkov Terraform
+
+on:
+  push:
+    branches: main
+  pull_request:
+
+jobs:
+  checkov-terraform:
+    name: Checkov Terraform
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v5
+
+      - name: Test Terraform with Checkov
+        uses: bridgecrewio/checkov-action@v12
+        with:
+          directory: .
+          framework: terraform

--- a/app-service-plan.tf
+++ b/app-service-plan.tf
@@ -1,6 +1,6 @@
 resource "azurerm_service_plan" "default" {
-  #checkov:skip=CKV_AZURE_212: Suppressing check pending review
-  #checkov:skip=CKV_AZURE_225: Suppressing check pending review
+  #checkov:skip=CKV_AZURE_212: Ensure App Service has a minimum number of instances for failover
+  #checkov:skip=CKV_AZURE_225: Ensure the App Service Plan is zone redundant
 
   name                = "${local.resource_prefix}default"
   resource_group_name = local.resource_group.name

--- a/app-service-plan.tf
+++ b/app-service-plan.tf
@@ -1,4 +1,7 @@
 resource "azurerm_service_plan" "default" {
+  #checkov:skip=CKV_AZURE_212: Suppressing check pending review
+  #checkov:skip=CKV_AZURE_225: Suppressing check pending review
+
   name                = "${local.resource_prefix}default"
   resource_group_name = local.resource_group.name
   location            = local.resource_group.location

--- a/app-service-windows.tf
+++ b/app-service-windows.tf
@@ -1,6 +1,13 @@
 resource "azurerm_windows_web_app" "default" {
   count = local.service_plan_os == "Windows" ? 1 : 0
 
+  #checkov:skip=CKV_AZURE_17: Suppressing check pending review
+  #checkov:skip=CKV_AZURE_78: Suppressing check pending review
+  #checkov:skip=CKV_AZURE_80: Suppressing check pending review
+  #checkov:skip=CKV_AZURE_13: Suppressing check pending review
+  #checkov:skip=CKV_AZURE_222: Suppressing check pending review
+  #checkov:skip=CKV_AZURE_88: Suppressing check pending review
+
   name                      = "${local.resource_prefix}default"
   resource_group_name       = local.resource_group.name
   location                  = local.resource_group.location

--- a/app-service-windows.tf
+++ b/app-service-windows.tf
@@ -1,19 +1,19 @@
 resource "azurerm_windows_web_app" "default" {
   count = local.service_plan_os == "Windows" ? 1 : 0
 
-  #checkov:skip=CKV_AZURE_17: Suppressing check pending review
-  #checkov:skip=CKV_AZURE_78: Suppressing check pending review
-  #checkov:skip=CKV_AZURE_80: Suppressing check pending review
-  #checkov:skip=CKV_AZURE_13: Suppressing check pending review
-  #checkov:skip=CKV_AZURE_222: Suppressing check pending review
-  #checkov:skip=CKV_AZURE_88: Suppressing check pending review
+  #checkov:skip=CKV_AZURE_17: Ensure the web app has 'Client Certificates (Incoming client certificates)' set
+  #checkov:skip=CKV_AZURE_78: Ensure FTP deployments are disabled
+  #checkov:skip=CKV_AZURE_80: Ensure that 'Net Framework' version is the latest, if used as a part of the web app
+  #checkov:skip=CKV_AZURE_13: Ensure App Service Authentication is set on Azure App Service
+  #checkov:skip=CKV_AZURE_88: Ensure that app services use Azure Files
 
-  name                      = "${local.resource_prefix}default"
-  resource_group_name       = local.resource_group.name
-  location                  = local.resource_group.location
-  service_plan_id           = azurerm_service_plan.default.id
-  virtual_network_subnet_id = local.launch_in_vnet ? azurerm_subnet.web_app_service_infra_subnet[0].id : null
-  https_only                = true
+  name                          = "${local.resource_prefix}default"
+  resource_group_name           = local.resource_group.name
+  location                      = local.resource_group.location
+  service_plan_id               = azurerm_service_plan.default.id
+  virtual_network_subnet_id     = local.launch_in_vnet ? azurerm_subnet.web_app_service_infra_subnet[0].id : null
+  https_only                    = true
+  public_network_access_enabled = false
 
   app_settings = merge(
     local.service_app_settings,

--- a/logs-storage.tf
+++ b/logs-storage.tf
@@ -1,25 +1,33 @@
 resource "azurerm_storage_account" "logs" {
   count = local.enable_service_logs ? 1 : 0
 
-  #checkov:skip=CKV_AZURE_59: Suppressing check pending review
-  #checkov:skip=CKV_AZURE_33: Suppressing check pending review
-  #checkov:skip=CKV_AZURE_190: Suppressing check pending review
-  #checkov:skip=CKV_AZURE_206: Suppressing check pending review
-  #checkov:skip=CKV2_AZURE_41: Suppressing check pending review
-  #checkov:skip=CKV2_AZURE_38: Suppressing check pending review
-  #checkov:skip=CKV2_AZURE_40: Suppressing check pending review
-  #checkov:skip=CKV2_AZURE_1: Suppressing check pending review
-  #checkov:skip=CKV2_AZURE_47: Suppressing check pending review
-  #checkov:skip=CKV2_AZURE_33: Suppressing check pending review
+  #checkov:skip=CKV_AZURE_33: Ensure Storage logging is enabled for Queue service for read, write and delete requests
+  #checkov:skip=CKV_AZURE_206: Ensure that Storage Accounts use replication
+  #checkov:skip=CKV2_AZURE_1: Ensure storage for critical data are encrypted with Customer Managed Key
+  #checkov:skip=CKV2_AZURE_33: Ensure storage account is configured with private endpoint
 
-  name                       = "${replace(local.resource_prefix, "-", "")}logs"
-  resource_group_name        = azurerm_resource_group.default[0].name
-  location                   = azurerm_resource_group.default[0].location
-  account_tier               = "Standard"
-  account_kind               = "StorageV2"
-  account_replication_type   = "LRS"
-  min_tls_version            = "TLS1_2"
-  https_traffic_only_enabled = true
+  name                            = "${replace(local.resource_prefix, "-", "")}logs"
+  resource_group_name             = azurerm_resource_group.default[0].name
+  location                        = azurerm_resource_group.default[0].location
+  account_tier                    = "Standard"
+  account_kind                    = "StorageV2"
+  account_replication_type        = "LRS"
+  min_tls_version                 = "TLS1_2"
+  https_traffic_only_enabled      = true
+  public_network_access_enabled   = false
+  allow_nested_items_to_be_public = false
+  shared_access_key_enabled       = true
+
+  #checkov:skip=CKV2_AZURE_40: Ensure storage account is not configured with Shared Key authorization
+  sas_policy {
+    expiration_period = "2.00:00:00"
+  }
+
+  blob_properties {
+    delete_retention_policy {
+      days = 7
+    }
+  }
 
   tags = local.tags
 }
@@ -27,7 +35,7 @@ resource "azurerm_storage_account" "logs" {
 resource "azurerm_storage_account_network_rules" "logs" {
   count = local.enable_service_logs ? 1 : 0
 
-  #checkov:skip=CKV2_AZURE_21: Suppressing check pending review
+  #checkov:skip=CKV2_AZURE_21: Azure storage account logging setting for blobs is disabled
 
   storage_account_id         = azurerm_storage_account.logs[0].id
   default_action             = "Deny"
@@ -42,7 +50,7 @@ resource "azurerm_storage_account_network_rules" "logs" {
 
 resource "azurerm_storage_container" "logs" {
 
-  #checkov:skip=CKV2_AZURE_21: Suppressing check pending review
+  #checkov:skip=CKV2_AZURE_21: Azure storage account logging setting for blobs is disabled
 
   for_each = local.enable_service_logs ? local.service_log_types : []
 

--- a/logs-storage.tf
+++ b/logs-storage.tf
@@ -1,6 +1,17 @@
 resource "azurerm_storage_account" "logs" {
   count = local.enable_service_logs ? 1 : 0
 
+  #checkov:skip=CKV_AZURE_59: Suppressing check pending review
+  #checkov:skip=CKV_AZURE_33: Suppressing check pending review
+  #checkov:skip=CKV_AZURE_190: Suppressing check pending review
+  #checkov:skip=CKV_AZURE_206: Suppressing check pending review
+  #checkov:skip=CKV2_AZURE_41: Suppressing check pending review
+  #checkov:skip=CKV2_AZURE_38: Suppressing check pending review
+  #checkov:skip=CKV2_AZURE_40: Suppressing check pending review
+  #checkov:skip=CKV2_AZURE_1: Suppressing check pending review
+  #checkov:skip=CKV2_AZURE_47: Suppressing check pending review
+  #checkov:skip=CKV2_AZURE_33: Suppressing check pending review
+
   name                       = "${replace(local.resource_prefix, "-", "")}logs"
   resource_group_name        = azurerm_resource_group.default[0].name
   location                   = azurerm_resource_group.default[0].location
@@ -16,6 +27,8 @@ resource "azurerm_storage_account" "logs" {
 resource "azurerm_storage_account_network_rules" "logs" {
   count = local.enable_service_logs ? 1 : 0
 
+  #checkov:skip=CKV2_AZURE_21: Suppressing check pending review
+
   storage_account_id         = azurerm_storage_account.logs[0].id
   default_action             = "Deny"
   bypass                     = ["AzureServices"]
@@ -28,6 +41,9 @@ resource "azurerm_storage_account_network_rules" "logs" {
 }
 
 resource "azurerm_storage_container" "logs" {
+
+  #checkov:skip=CKV2_AZURE_21: Suppressing check pending review
+
   for_each = local.enable_service_logs ? local.service_log_types : []
 
   name                  = "${local.resource_prefix}${each.value}logs"


### PR DESCRIPTION
Add a github workflow to scan for terraform vulnerabilities using Checkov.

### Currently suppressing:

#### log-storage.tf
- CKV_AZURE_33: Ensure Storage logging is enabled for Queue service for read, write and delete requests
- CKV_AZURE_206: Ensure that Storage Accounts use replication
- CKV2_AZURE_40: Ensure storage account is not configured with Shared Key authorization
- CKV2_AZURE_1: Ensure storage for critical data are encrypted with Customer Managed Key
- CKV2_AZURE_33: Ensure storage account is configured with private endpoint
- 
#### app-service-plan.tf

- CKV_AZURE_212: Ensure App Service has a minimum number of instances for failover
- CKV_AZURE_225: Ensure the App Service Plan is zone redundant

#### app-service-windows.tf

- CKV_AZURE_17: Ensure the web app has 'Client Certificates (Incoming client certificates)' set
- CKV_AZURE_78: Ensure FTP deployments are disabled
- CKV_AZURE_80: Ensure that 'Net Framework' version is the latest, if used as a part of the web app
- CKV_AZURE_13: Ensure App Service Authentication is set on Azure App Service
- CKV_AZURE_88: Ensure that app services use Azure Files